### PR TITLE
fix: use Async variant for AvatarEditorService:SearchCatalog

### DIFF
--- a/src/Client/UI/StateExtensions/CatalogSearch.luau
+++ b/src/Client/UI/StateExtensions/CatalogSearch.luau
@@ -95,7 +95,7 @@ function CatalogSearch.Pages(Params: SearchParams)
 	local CatalogSearchParams = CatalogSearch.Params(Params)
 
 	return Future.Try(function()
-		return AvatarEditorService:SearchCatalog(CatalogSearchParams)
+		return AvatarEditorService:SearchCatalogAsync(CatalogSearchParams)
 	end)
 end
 


### PR DESCRIPTION
Source: https://devforum.roblox.com/t/psa-several-common-yielding-methods-have-been-renamed/4257585