### PR TITLE
fix: use Async variant for AvatarEditorService:GetInventory

### DIFF
--- a/src/Client/UI/StateExtensions/Inventory.luau
+++ b/src/Client/UI/StateExtensions/Inventory.luau
@@ -67,7 +67,7 @@ end
 
 function Inventory.Pages(AssetTypes: { Enum.AvatarAssetType }?)
 	return Future.Try(function()
-		return AvatarEditorService:GetInventory(AssetTypes)
+		return AvatarEditorService:GetInventoryAsync(AssetTypes)
 	end)
 end
 


### PR DESCRIPTION
Source: https://devforum.roblox.com/t/psa-several-common-yielding-methods-have-been-renamed/4257585